### PR TITLE
Python 3.9 wants newer pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2-binary==2.8.6
 django==3.2.7
-pillow==7.1.1
+Pillow==9.0.1


### PR DESCRIPTION
Currently we use Pillow 7.1.1 which [doesn't work with Python 3.9](https://pillow.readthedocs.io/en/latest/installation.html#python-support).
