### PR TITLE
Bumps django from 3.2.7 to 4.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2-binary==2.8.6
-django==3.2.7
+django==4.0.4
 Pillow==9.0.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='jsonate',
-    version='0.7.4',
+    version='0.7.5',
 
     author='James Robert',
     author_email='jiaaro@gmail.com',
@@ -17,7 +17,7 @@ setup(
     url='http://jsonate.com',
 
     install_requires=[
-        "django>=3.0",
+        "django>=4.0.4",
     ],
 
     packages=[


### PR DESCRIPTION
[#2812](https://github.com/mediapredict/mediapredict/issues/2812)
- Bumps [django ](https://github.com/django/django)from 3.2.7 to 4.0.4 
- Increased minor version to 0.7.5
- set min django install_requires to 4.0.4